### PR TITLE
Converted script references to URL-relative paths.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -20,19 +20,19 @@
 
 	</head>
 
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,400italic' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Open+Sans:400,400italic' rel='stylesheet' type='text/css'>
 
 	<!-- JS Dependencies -->
 	<script src="/util.js"></script>
 	<script src="/underscore-min.js"></script>
 	<script src="/jquery.typewatch.js"></script>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/moment.js/2.0.0/moment.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.0.0/moment.min.js"></script>
 
 	<!-- Non-foundation custom CSS -->
 	<link rel="stylesheet" href="/appStyle.css"> 
 
 	<!-- Load Ractive --> 
-	<script src='http://cdn.ractivejs.org/latest/ractive.js'></script>
+	<script src='//cdn.ractivejs.org/latest/ractive.js'></script>
 
 	<!-- Main application code -->
 	<script src="/main.js"></script>


### PR DESCRIPTION
This prevents browsers from blocking scripts due to mixed-content violations.

Currently, MomentJS and Ractive are being blocked from loading by Chrome and Firefox due to rules about mixing secure (https) and non-secure content. This should resolve that issue.
